### PR TITLE
editing workout time was off because the actual times were not being …

### DIFF
--- a/frontend/screens/calendar.js
+++ b/frontend/screens/calendar.js
@@ -144,8 +144,8 @@ const CalendarScreen = ({}) => {
     const handleConfirm = (date) => {
       date = moment.utc(date).subtract(new Date().getTimezoneOffset(), 'minute')
       const formattedDate = moment.utc(date).format('YYYY-MM-DDTHH:mm');
-      const now = moment.utc();
-    
+      const now = moment.utc().subtract(new Date().getTimezoneOffset(), 'minute')
+      // console.log("now", now, "date", date);
       if (date.isBefore(now)) {
         setIsDateValid(false);
         Alert.alert('Error', 'Dates cannot be selected in the past.');


### PR DESCRIPTION
If yall think its worth it. This is a quick fix. It fixes a bug about scheduling in the past which accidentally included the next 4 hours as "in the past" which definitely isn't the case. This way it works as saying you can't schedule for any date in the past including your current date,time,minute but it allows you to schedule even one minute ahead. If we don't want to PR then maybe test using this branch to see what it acts like and compare to main